### PR TITLE
Unknown element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <title>Custom elements demo</title>
-    <link href="https://cityofphiladelphia.github.io/standards/css/styles.css" rel="stylesheet">
+    <link href="https://cityofphiladelphia.github.io/standards-docs/css/standards.css" rel="stylesheet">
   </head>
   <body>
     <div class="row">

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,23 +1,19 @@
 const classNames = require('classnames')
 
-class PHLButton extends window.HTMLElement {
-  connectedCallback () {
-    const href = this.getAttribute('href')
-    const icon = this.getAttribute('icon')
-    const contents = this.innerText
-    const classes = this.className.split(' ')
-    const combinedClasses = classNames('button', 'icon', classes)
+module.exports = function PHLButton (el) {
+  const href = el.getAttribute('href')
+  const icon = el.getAttribute('icon')
+  const contents = el.innerText
+  const classes = el.className.split(' ')
+  const combinedClasses = classNames('button', 'icon', classes)
 
-    const template = `
-      <a href=${href} class="${combinedClasses}">
-        <div class="valign">
-          ${icon ? `<i class="fa ${icon} valign-cell"></i>` : ''}
-          <div class="button-label valign-cell">${contents}</div>
-        </div>
-      </a>
-    `
-    this.innerHTML = template
-  }
+  const template = `
+    <a href=${href} class="${combinedClasses}">
+      <div class="valign">
+        ${icon ? `<i class="fa ${icon} valign-cell"></i>` : ''}
+        <div class="button-label valign-cell">${contents}</div>
+      </div>
+    </a>
+  `
+  el.innerHTML = template
 }
-
-module.exports = PHLButton

--- a/src/components/service-update.js
+++ b/src/components/service-update.js
@@ -1,47 +1,43 @@
 const classNames = require('classnames')
 
-class PHLServiceUpdate extends window.HTMLElement {
-  connectedCallback () {
-    const level = this.getAttribute('level') || ''
-    const icon = this.getAttribute('icon') || ''
-    const label = this.getAttribute('label') || ''
-    const contents = this.innerHTML
+module.exports = function PHLServiceUpdate (el) {
+  const level = el.getAttribute('level') || ''
+  const icon = el.getAttribute('icon') || ''
+  const label = el.getAttribute('label') || ''
+  const contents = el.innerHTML
 
-    const classes = classNames([
-      'row',
-      'collapse',
-      'equal-height',
-      'service-update',
-      level ? `service-update--${level}` : null
-    ])
+  const classes = classNames([
+    'row',
+    'collapse',
+    'equal-height',
+    'service-update',
+    level ? `service-update--${level}` : null
+  ])
 
-    const template = `
-      <div class="${classes}">
-        <div class="small-6 columns equal">
-          <div class="icon valign">
-            <div class="valign-cell phl-mu">
-              <i class="fa ${icon} fa-2x fa-fw" aria-hidden="true"></i>
-              <span class="icon-label">${label}</span>
-            </div>
-          </div>
-        </div>
-        <div class="small-18 columns equal">
-          <div class="details valign">
-            <div class="valign-cell pam">
-              ${contents}
-            </div>
+  const template = `
+    <div class="${classes}">
+      <div class="small-6 columns equal">
+        <div class="icon valign">
+          <div class="valign-cell phl-mu">
+            <i class="fa ${icon} fa-2x fa-fw" aria-hidden="true"></i>
+            <span class="icon-label">${label}</span>
           </div>
         </div>
       </div>
-    `
-    this.innerHTML = template
+      <div class="small-18 columns equal">
+        <div class="details valign">
+          <div class="valign-cell pam">
+            ${contents}
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+  el.innerHTML = template
 
-    const columns = this.querySelectorAll('.columns')
-    setEqualHeight(columns)
-  }
+  const columns = el.querySelectorAll('.columns')
+  setEqualHeight(columns)
 }
-
-module.exports = PHLServiceUpdate
 
 function setEqualHeight (nodeList) {
   const els = Array.prototype.slice.call(nodeList) // convert to array

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
-const PHLButton = require('./components/button')
-const PHLServiceUpdate = require('./components/service-update')
+activate('phl-button', require('./components/button'))
+activate('phl-service-update', require('./components/service-update'))
 
-window.customElements.define('phl-button', PHLButton)
-window.customElements.define('phl-service-update', PHLServiceUpdate)
+function activate (query, fn) {
+  const elsNodeList = document.querySelectorAll(query)
+  const elsArray = [].slice.call(elsNodeList)
+  elsArray.forEach(fn)
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,19 @@
+const test = require('tape')
+
+test('button', (t) => {
+  const input = trim(`
+    <phl-button href="foo" icon="fa-bullhorn">Hello, world!</phl-button>
+  `)
+  const expect = trim(`
+    <a href="foo" class="button icon full-width">
+      <div class="valign">
+        <i class="fa fa-bullhorn valign-cell"></i>
+        <div class="button-label valign-cell">Hello, world!</div>
+      </div>
+    </a>
+  `)
+})
+
+function trim (text) {
+  return text.replace(/^ +/gm, '') // global, multiline
+}


### PR DESCRIPTION
Uses vanilla HTML elements (fake/unknown ones) and enriches them, instead of using the custom element spec. Once we replace things like `const` and `querySelectorAll` with older browser supporting versions, this should work pretty well in older browsers, in theory.

[Demo](http://phl-standards-unknown-elements.surge.sh/)

/cc @karissademi @awm33